### PR TITLE
address rails3 deprecation: change all instances of RAILS_ROOT to Rails.root.to_s

### DIFF
--- a/lib/calendar_date_select.rb
+++ b/lib/calendar_date_select.rb
@@ -22,10 +22,10 @@ if Object.const_defined?(:Rails) && File.directory?(Rails.root.to_s + "/public")
   end
 
   # install files
-  unless File.exists?(RAILS_ROOT + '/public/javascripts/calendar_date_select/calendar_date_select.js')
+  unless File.exists?(Rails.root.to_s + '/public/javascripts/calendar_date_select/calendar_date_select.js')
     ['/public', '/public/javascripts/calendar_date_select', '/public/stylesheets/calendar_date_select', '/public/images/calendar_date_select', '/public/javascripts/calendar_date_select/locale'].each do |dir|
       source = File.dirname(__FILE__) + "/../#{dir}"
-      dest = RAILS_ROOT + dir
+      dest = Rails.root.to_s + dir
       FileUtils.mkdir_p(dest)
       FileUtils.cp(Dir.glob(source+'/*.*'), dest)
     end


### PR DESCRIPTION
address rails3 deprecation: change all instances of RAILS_ROOT to Rails.root.to_s
