### PR TITLE
fix for use of calendar_date_select as gem

### DIFF
--- a/lib/calendar_date_select.rb
+++ b/lib/calendar_date_select.rb
@@ -1,6 +1,7 @@
 require "calendar_date_select/calendar_date_select.rb"
 require "calendar_date_select/form_helpers.rb"
 require "calendar_date_select/includes_helper.rb"
+require "action_view/helpers"
 
 if Object.const_defined?(:Rails) && File.directory?(Rails.root.to_s + "/public")  
   ActionView::Helpers::FormHelper.send(:include, CalendarDateSelect::FormHelpers)


### PR DESCRIPTION
action view helpers needs to be manually loaded inside lib. once merged can you please bump out new version of gem. It will help in centralize management of source code.
