### PR TITLE
Make release dates reasonable

### DIFF
--- a/calendar_date_select.gemspec
+++ b/calendar_date_select.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Shih-gian Lee", "Enrique Garcia Cota (kikito)", "Tim Charper", "Lars E. Hoeg"]
-  s.date = %q{2010-03-29}
   s.description = %q{Calendar date picker for rails}
   s.email = %q{}
   s.extra_rdoc_files = [


### PR DESCRIPTION
All recent releases were made on the "same date" [1]. That is not cool. Hopefully this pull request will change that (although I did not test this change).

[1] https://rubygems.org/gems/calendar_date_select
