### PR TITLE
strip gemspec down to the essentials

### DIFF
--- a/calendar_date_select.gemspec
+++ b/calendar_date_select.gemspec
@@ -3,21 +3,15 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'calendar_date_select/version'
 
-Gem::Specification.new do |spec|
-  spec.name          = "calendar_date_select"
-  spec.version       = CalendarDateSelect::VERSION
-
+Gem::Specification.new "calendar_date_select", CalendarDateSelect::VERSION do |spec|
   spec.authors       = ["Shih-gian Lee", "Enrique Garcia Cota (kikito)", "Tim Charper", "Lars E. Hoeg", "Marc-André Lafortune"]
   spec.email         = ["github@marc-andre.ca"]
-  spec.description   = %q{Calendar date picker for rails}
-  spec.summary       = %q{Calendar date picker for rails}
+  spec.description   = "Calendar date picker for rails"
+  spec.summary       = "Calendar date picker for rails"
   spec.homepage      = "http://github.com/marcandre/calendar_date_select"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.files         = `git ls-files lib app MIT-LICENSE`.split($/)
 
   spec.add_dependency "rails", ">= 3.1"
 


### PR DESCRIPTION
- nice formatting
- makes the gem lighter -> faster to install / less weight if vendored and committed

@marcandre
